### PR TITLE
Skip non mask aux, remove cost padding

### DIFF
--- a/src/hepattn/models/maskformer.py
+++ b/src/hepattn/models/maskformer.py
@@ -2,6 +2,7 @@ import torch
 from torch import Tensor, nn
 
 from hepattn.models.decoder import MaskFormerDecoderLayer
+from hepattn.models.task import ObjectHitMaskTask
 
 
 class MaskFormer(nn.Module):
@@ -224,6 +225,9 @@ class MaskFormer(nn.Module):
             layer_costs = None
             # Get the cost contribution from each of the tasks
             for task in self.tasks:
+                # Skip tasks that are not ObjectHitMaskTask for intermediate layers
+                if layer_name != "final" and not isinstance(task, ObjectHitMaskTask):
+                    continue
                 # Only use the cost from the final set of predictions
                 task_costs = task.cost(layer_outputs[task.name], targets)
 
@@ -256,6 +260,9 @@ class MaskFormer(nn.Module):
                 continue
             losses[layer_name] = {}
             for task in self.tasks:
+                # Skip tasks that are not ObjectHitMaskTask for intermediate layers
+                if layer_name != "final" and not isinstance(task, ObjectHitMaskTask):
+                    continue
                 losses[layer_name][task.name] = task.loss(outputs[layer_name][task.name], targets)
 
         return losses

--- a/src/hepattn/models/task.py
+++ b/src/hepattn/models/task.py
@@ -7,9 +7,6 @@ from torch import Tensor, nn
 from hepattn.models.dense import Dense
 from hepattn.models.loss import cost_fns, focal_loss, loss_fns
 
-# Pick a value that is safe for float16
-COST_PAD_VALUE = 1e4
-
 
 class Task(nn.Module, ABC):
     def __init__(self):
@@ -110,8 +107,6 @@ class ObjectValidTask(Task):
         costs = {}
         for cost_fn, cost_weight in self.costs.items():
             costs[cost_fn] = cost_weight * cost_fns[cost_fn](output, target)
-            # Set the costs of invalid objects to be (basically) inf
-            costs[cost_fn][~targets[self.target_object + "_valid"].unsqueeze(-2).expand_as(costs[cost_fn])] = COST_PAD_VALUE
         return costs
 
     def loss(self, outputs, targets):
@@ -264,9 +259,6 @@ class ObjectHitMaskTask(Task):
         costs = {}
         for cost_fn, cost_weight in self.costs.items():
             costs[cost_fn] = cost_weight * cost_fns[cost_fn](output, target)
-
-            # Set the costs of invalid objects to be (basically) inf
-            costs[cost_fn][~targets[self.target_object + "_valid"].unsqueeze(-2).expand_as(costs[cost_fn])] = COST_PAD_VALUE
         return costs
 
     def loss(self, outputs, targets):


### PR DESCRIPTION
closes #40, removing the non-mask intermediate costs gives a small speed up and a noticable performance boost.

Removing manual cost padding since it's taken care of in the matcher (see #35)

