### PR TITLE
Improve object valid costs

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -236,6 +236,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl
       - pypi: https://download.pytorch.org/whl/test/pyparsing-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/6d1e368710cb6c458ed692d179d7e101ebce80a3e640b2e74cc7ae886d6f/python_box-6.1.0-py3-none-any.whl
       - pypi: https://download.pytorch.org/whl/test/python_dateutil-2.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/a9/e14821cfaf08e8d78185cca0477c9d3a62bafe1b4b530100f7b66bb1f7bb/pytorch_lightning-2.5.1.post0-py3-none-any.whl
@@ -1491,13 +1492,14 @@ packages:
 - pypi: .
   name: hepattn
   version: 0.1.0
-  sha256: 97ef1714ec500133cf79488ebcad6388ccbda9a40730827c1320727903bf3fa2
+  sha256: a45cf809245d46cc3bd282eb8be77d8664aa79b9075e4239816ac25c475ed434
   requires_dist:
   - packaging
   - wheel
   - numpy
   - scipy
   - pytest>=8.3.3,<9
+  - pytest-repeat
   - ruff==0.8.0
   - pre-commit>=4.0.1,<5
   - matplotlib==3.9.*
@@ -3149,6 +3151,13 @@ packages:
   - setuptools ; extra == 'dev'
   - xmlschema ; extra == 'dev'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl
+  name: pytest-repeat
+  version: 0.9.4
+  sha256: c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3
+  requires_dist:
+  - pytest
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.11-h9e4cc4f_0_cpython.conda
   sha256: 6cca004806ceceea9585d4d655059e951152fc774a471593d4f5138e6a54c81d
   md5: 94206474a5608243a10c92cefbe0908f

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "numpy",
     "scipy",
     "pytest>=8.3.3,<9",
+    "pytest-repeat",
     "ruff==0.8.0",
     "pre-commit>=4.0.1,<5",
     "matplotlib==3.9.*",

--- a/src/hepattn/experiments/trackml/run_tracking.py
+++ b/src/hepattn/experiments/trackml/run_tracking.py
@@ -67,8 +67,9 @@ class TrackMLTracker(ModelWrapper):
         self.log(f"{stage}/nh_per_particle", torch.mean(nh_per_true.float()), sync_dist=True)
         self.log(f"{stage}/nh_per_track", torch.mean(nh_per_pred.float()), sync_dist=True)
 
-        self.log(f"{stage}/num_particles", torch.mean(pred_num.float()), sync_dist=True)
-        self.log(f"{stage}/num_tracks", torch.mean(true_num.float()), sync_dist=True)
+        self.log(f"{stage}/num_tracks", torch.mean(pred_num.float()), sync_dist=True)
+        self.log(f"{stage}/num_particles", torch.mean(true_num.float()), sync_dist=True)
+
 
 
 def main(args: ArgsType = None) -> None:

--- a/src/hepattn/models/loss.py
+++ b/src/hepattn/models/loss.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 
 
-def object_bce_loss(pred_logits, true, mask=None, weight=None):
+def object_bce_loss(pred_logits, true, mask=None, weight=None):  # noqa: ARG001
     losses = F.binary_cross_entropy_with_logits(pred_logits, true, weight=weight)
     return losses.mean()
 

--- a/src/hepattn/models/loss.py
+++ b/src/hepattn/models/loss.py
@@ -2,17 +2,48 @@ import torch
 import torch.nn.functional as F
 
 
-def object_bce_loss(pred_logits, true, mask=None, weight=None):  # noqa: ARG001
-    # TODO: Add support for mask?
+def object_bce_loss(pred_logits, true, mask=None, weight=None):
     losses = F.binary_cross_entropy_with_logits(pred_logits, true, weight=weight)
     return losses.mean()
 
 
-def object_bce_costs(pred_logits, true):
-    costs = F.binary_cross_entropy_with_logits(
-        pred_logits.unsqueeze(2).expand(-1, -1, true.shape[1]), true.unsqueeze(1).expand(-1, pred_logits.shape[1], -1), reduction="none"
-    )
-    return costs
+def object_bce_cost(pred_logits, target_labels):
+    """
+    Compute batched binary object classification cost for object matching.
+    Approximate the CE loss using -probs[target_class].
+
+    Args:
+        pred_logits: [batch_size, num_queries] - predicted logits for binary classification
+        target_labels: [batch_size, num_targets] - ground truth class labels
+
+    Returns:
+        cost_class: [batch_size, num_queries, num_targets] - classification cost matrix
+    """
+    out_prob = pred_logits.sigmoid().unsqueeze(-1)
+    target_labels = target_labels.unsqueeze(1)
+    return -out_prob * target_labels - (1 - out_prob) * (1 - target_labels)
+
+
+def object_ce_cost(pred_logits, target_labels):
+    """
+    Compute batched mutliclass object classification cost for object matching.
+    Approximate the CE loss using -probs[target_class].
+
+    Args:
+        pred_logits: [batch_size, num_queries, num_classes] - predicted logits (num_classes>1)
+        target_labels: [batch_size, num_targets] - ground truth class labels
+
+    Returns:
+        cost_class: [batch_size, num_queries, num_targets] - classification cost matrix
+    """
+    assert pred_logits.shape[-1] > 1
+    out_prob = pred_logits.softmax(-1)
+
+    batch_size, num_queries, _ = out_prob.shape
+    num_targets = target_labels.size(1)
+
+    index = target_labels.unsqueeze(1).expand(batch_size, num_queries, num_targets)
+    return -torch.gather(out_prob, dim=2, index=index)
 
 
 def mask_dice_loss(pred_logits, true, mask=None, weight=None, eps=1e-6):
@@ -131,7 +162,8 @@ def regr_smooth_l1_costs(pred, true):
 
 
 cost_fns = {
-    "object_bce": object_bce_costs,
+    "object_bce": object_bce_cost,
+    "object_ce": object_ce_cost,
     "mask_bce": mask_bce_costs,
     "mask_dice": mask_dice_costs,
     "mask_focal": mask_focal_costs,

--- a/tests/matching/test_costs.py
+++ b/tests/matching/test_costs.py
@@ -1,0 +1,89 @@
+import pytest
+import torch
+
+from hepattn.models.loss import object_bce_cost, object_ce_cost
+
+torch.manual_seed(42)
+
+
+def compute_class_cost_unbatched(pred_logits, target_labels):
+    """Compute classification cost for object matching."""
+    if pred_logits.shape[-1] == 1:
+        # Binary classification
+        out_prob = pred_logits.sigmoid().squeeze(-1)
+        cost_class = -out_prob.unsqueeze(1) * target_labels.unsqueeze(0) - (1 - out_prob.unsqueeze(1)) * (1 - target_labels.unsqueeze(0))
+    else:
+        # Multi-class
+        out_prob = pred_logits.softmax(-1)
+        cost_class = -out_prob[:, target_labels]
+    return cost_class
+
+
+def test_binary_classification_equivalence():
+    """Test that binary classification with num_classes=1 and num_classes=2 produce equivalent results."""
+    num_queries = 5
+    num_targets = 3
+
+    pred_logits_1class = torch.randn(num_queries, 1)
+
+    pred_logits_2class = torch.zeros(num_queries, 2)
+    pred_logits_2class[:, 1] = pred_logits_1class.squeeze(-1)
+
+    target_labels = torch.randint(0, 2, (num_targets,))
+
+    cost_1class = compute_class_cost_unbatched(pred_logits_1class, target_labels)
+    cost_2class = compute_class_cost_unbatched(pred_logits_2class, target_labels)
+
+    torch.testing.assert_close(cost_1class, cost_2class, rtol=1e-5, atol=1e-6)
+    assert cost_1class.shape == (num_queries, num_targets)
+    assert cost_2class.shape == (num_queries, num_targets)
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("batch_size", [1, 10, 100])
+def test_object_bce_cost(batch_size):
+    """Test that batched and unbatched implementations produce equivalent results."""
+    num_queries = 100
+    num_targets = 100
+    num_classes = 1
+
+    pred_logits_batched = torch.randn(batch_size, num_queries, num_classes)
+    target_labels_batched = torch.randint(0, 2, (batch_size, num_targets))
+
+    cost_batched = object_bce_cost(pred_logits_batched, target_labels_batched)
+
+    costs_unbatched = []
+    for b in range(batch_size):
+        cost_single = compute_class_cost_unbatched(pred_logits_batched[b], target_labels_batched[b])
+        costs_unbatched.append(cost_single)
+
+    cost_unbatched_stacked = torch.stack(costs_unbatched, dim=0)
+
+    torch.testing.assert_close(cost_batched, cost_unbatched_stacked, rtol=1e-5, atol=1e-6)
+    assert cost_batched.shape == (batch_size, num_queries, num_targets)
+    assert cost_unbatched_stacked.shape == (batch_size, num_queries, num_targets)
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("batch_size", [1, 10, 100])
+def test_object_ce_cost(batch_size):
+    """Test that batched and unbatched implementations produce equivalent results."""
+    num_queries = 100
+    num_targets = 100
+    num_classes = 3
+
+    pred_logits_batched = torch.randn(batch_size, num_queries, num_classes)
+    target_labels_batched = torch.randint(0, num_classes, (batch_size, num_targets))
+
+    cost_batched = object_ce_cost(pred_logits_batched, target_labels_batched)
+
+    costs_unbatched = []
+    for b in range(batch_size):
+        cost_single = compute_class_cost_unbatched(pred_logits_batched[b], target_labels_batched[b])
+        costs_unbatched.append(cost_single)
+
+    cost_unbatched_stacked = torch.stack(costs_unbatched, dim=0)
+
+    torch.testing.assert_close(cost_batched, cost_unbatched_stacked, rtol=1e-5, atol=1e-6)
+    assert cost_batched.shape == (batch_size, num_queries, num_targets)
+    assert cost_unbatched_stacked.shape == (batch_size, num_queries, num_targets)


### PR DESCRIPTION
Using `binary_cross_entropy_with_logits` for the cost is not ideal as it should really only be calculated for the positive samples. We can also approximate the cost as `-probs[target_class]` as done here.