### PR TITLE
Add parallel matching

### DIFF
--- a/src/hepattn/models/matcher.py
+++ b/src/hepattn/models/matcher.py
@@ -23,9 +23,16 @@ def solve_1015_late(cost):
     return lap1015.lap_late(cost)
 
 
+SOLVERS = {
+    "scipy": solve_scipy,
+    # "1015_early": solve_1015_early,
+    "1015_late": solve_1015_late,
+}
+
+
 def match_individual(solver_fn, cost: np.ndarray, default_idx: torch.Tensor) -> torch.Tensor:
     pred_idx = torch.as_tensor(solver_fn(cost))
-    if solver_fn == solve_scipy:
+    if solver_fn == SOLVERS["scipy"]:
         pred_idx = torch.concatenate([pred_idx, default_idx[~torch.isin(default_idx, pred_idx)]])
     return pred_idx
 
@@ -38,13 +45,6 @@ def match_parallel(solver_fn, costs: np.ndarray, batch_obj_lengths: torch.Tensor
         # Use the pool to map the function to the arguments
         pred_idxs = pool.starmap(match_individual, args)
     return torch.stack(pred_idxs, dim=0)
-
-
-SOLVERS = {
-    "scipy": solve_scipy,
-    # "1015_early": solve_1015_early,
-    "1015_late": solve_1015_late,
-}
 
 
 class Matcher(nn.Module):

--- a/src/hepattn/models/matcher.py
+++ b/src/hepattn/models/matcher.py
@@ -2,7 +2,10 @@ import time
 
 import scipy
 import torch
+import numpy as np
 from torch import nn
+
+from multiprocessing.pool import ThreadPool as Pool
 
 import lap1015
 
@@ -20,6 +23,23 @@ def solve_1015_late(cost):
     return lap1015.lap_late(cost)
 
 
+def match_individual(solver_fn, cost: np.ndarray, default_idx: torch.Tensor) -> torch.Tensor:
+    pred_idx = torch.as_tensor(solver_fn(cost))
+    if solver_fn == solve_scipy:
+        pred_idx = torch.concatenate([pred_idx, default_idx[~torch.isin(default_idx, pred_idx)]])
+    return pred_idx
+
+
+def match_parallel(solver_fn, costs: np.ndarray, batch_obj_lengths: torch.Tensor, n_jobs: int = 8) -> torch.Tensor:
+    default_idx = torch.arange(costs.shape[2])
+    with Pool(processes=n_jobs) as pool:
+        # Prepare the arguments for the parallel function
+        args = ((solver_fn, costs[k][:, : batch_obj_lengths[k]].T, default_idx) for k in range(len(costs)))
+        # Use the pool to map the function to the arguments
+        pred_idxs = pool.starmap(match_individual, args)
+    return torch.stack(pred_idxs, dim=0)
+
+
 SOLVERS = {
     "scipy": solve_scipy,
     # "1015_early": solve_1015_early,
@@ -33,6 +53,8 @@ class Matcher(nn.Module):
         default_solver: str = "scipy",
         adaptive_solver: bool = True,
         adaptive_check_interval: int = 1000,
+        parallel_solver: bool = False,
+        n_jobs: int = 8,
     ):
         super().__init__()
         """ Used to match predictions to targets based on a given cost matrix.
@@ -47,12 +69,18 @@ class Matcher(nn.Module):
             is then set as the current solver.
         adaptive_check_interval: bool
             Interval for checking which solver is the fastest.
+        parallel_solver: bool
+            If true, then the solver will use a parallel implementation to speed up the matching.
+        n_jobs: int
+            Number of jobs to use for parallel matching. Only used if parallel_solver is True.
         """
         if default_solver not in SOLVERS:
             raise ValueError(f"Unknown solver: {default_solver}. Available solvers: {list(SOLVERS.keys())}")
         self.solver = SOLVERS[default_solver]
         self.adaptive_solver = adaptive_solver
         self.adaptive_check_interval = adaptive_check_interval
+        self.parallel_solver = parallel_solver
+        self.n_jobs = n_jobs
         self.step = 0
 
     def compute_matching(self, costs, object_valid_mask=None):
@@ -65,16 +93,17 @@ class Matcher(nn.Module):
         idxs = []
         default_idx = torch.arange(costs.shape[2])
 
+        if self.parallel_solver:
+            # If we are using a parallel solver, we can use it to speed up the matching
+            pred_idxs = match_parallel(self.solver, costs, batch_obj_lengths, n_jobs=self.n_jobs)
+            return pred_idxs
+
         # Do the matching sequentially for each example in the batch
         for k in range(len(costs)):
             # remove invalid targets for efficiency
             cost = costs[k][:, : batch_obj_lengths[k]].T
-            pred_idx = torch.as_tensor(self.solver(cost), device=cost.device)
-
-            # scipy returns incomplete assignments, handle that here
-            if self.solver == SOLVERS["scipy"]:
-                pred_idx = torch.concatenate([pred_idx, default_idx[~torch.isin(default_idx, pred_idx)]])
-
+            # Solve the matching problem using the current solver
+            pred_idx = match_individual(self.solver, cost, default_idx)
             # These indicies can be used to permute the predictions so they now match the truth objects
             idxs.append(pred_idx)
 

--- a/tests/matching/test_match_equivalence.py
+++ b/tests/matching/test_match_equivalence.py
@@ -6,6 +6,16 @@ import torch
 
 from hepattn.models.matcher import SOLVERS, Matcher
 
+def generate_dummy_cost(rng: np.random.Generator, batch_size: int, n_objects: int, scale: float = 1.0) -> tuple[np.ndarray, np.ndarray]:
+    cost = rng.random((batch_size, n_objects, n_objects)) * scale  # Add batch dimension
+    object_valid_mask = np.zeros((batch_size, n_objects), dtype=bool)
+    for i in range(batch_size):
+        # Randomly set a portion of objects as valid
+        n_valid_objects = rng.integers(n_objects // 4, n_objects // 2)
+        object_valid_mask[i, :n_valid_objects] = True
+    cost[~object_valid_mask[:, None, :].repeat(n_objects, 1)] = 1e4  # Set padding costs to large value
+    return cost, object_valid_mask
+
 
 @pytest.mark.parametrize("solver", SOLVERS)
 @pytest.mark.parametrize("scale", [1.0, 10.0, 100.0, 1000.0])
@@ -15,15 +25,12 @@ def test_matcher_with_target_padding(solver, scale: float):
 
     for _ in range(10):
         n_objects = rng.integers(100, 250)
-        n_valid_objects = rng.integers(n_objects // 4, n_objects // 2)
-        cost = rng.random((1, n_objects, n_objects)) * scale  # Add batch dimension
-        object_valid_mask = np.zeros((1, n_objects), dtype=bool)  # Add batch dimension
-        object_valid_mask[0, :n_valid_objects] = True
-        cost[0, :, ~object_valid_mask[0]] = 1e4  # Set padding costs
+        cost, object_valid_mask = generate_dummy_cost(rng, 1, n_objects, scale)
 
         # Convert to torch tensors
         cost_tensor = torch.from_numpy(cost).float()
         object_valid_mask = torch.from_numpy(object_valid_mask)
+        n_valid_objects = object_valid_mask.sum()
 
         # Test with full cost matrix
         idx_all = matcher(cost_tensor).squeeze(0).numpy()
@@ -43,21 +50,56 @@ def test_matcher_with_target_padding(solver, scale: float):
             f"Solver {solver} produced duplicate indices for padded n_objects={n_objects}, n_valid_objects={n_valid_objects}"
         )
 
+@pytest.mark.parametrize("solver", SOLVERS)
+@pytest.mark.parametrize("scale", [1.0, 10.0, 100.0, 1000.0])
+def test_matcher_with_parallel_solver(solver, scale: float):
+    matcher = Matcher(default_solver=solver, adaptive_solver=False)
+    matcher_parallel = Matcher(default_solver=solver, adaptive_solver=False, parallel_solver=True)
+    rng = np.random.default_rng()
+    batch_size = 32
+    for _ in range(10):
+        n_objects = rng.integers(100, 250)
+        cost, object_valid_mask = generate_dummy_cost(rng, batch_size, n_objects, scale)
+
+        # Convert to torch tensors
+        cost_tensor = torch.from_numpy(cost).float()
+        object_valid_mask = torch.from_numpy(object_valid_mask)
+
+        idxs = matcher(cost_tensor, object_valid_mask).numpy()
+        idxs_parallel = matcher_parallel(cost_tensor, object_valid_mask).numpy()
+        object_valid_mask = object_valid_mask.numpy()
+
+        assert idxs_parallel.shape == (batch_size, n_objects), (
+            f"Parallel Solver {solver} produced incorrect shape for idxs: {idxs_parallel.shape}, expected {(batch_size, n_objects)}"
+        )
+        assert np.all(
+            idxs_parallel[object_valid_mask] == idxs[object_valid_mask]
+        ), (
+            f"Parallel Solver {solver} produced different indices for valid objects: {np.where(object_valid_mask)[0]}"
+            f" for n_objects={n_objects}, batch_size={batch_size}, scale={scale}"
+        )
+        assert np.all(
+            idxs_parallel[~object_valid_mask] == idxs[~object_valid_mask]
+        ), (
+            f"Parallel Solver {solver} produced different indices for invalid objects: {np.where(~object_valid_mask)[0]}"
+            f" for n_objects={n_objects}, batch_size={batch_size}, scale={scale}"
+        )
+
+
+
 
 @pytest.mark.parametrize("solver", SOLVERS)
-def test_matcher_speed(solver):
-    matcher = Matcher(default_solver=solver, adaptive_solver=False)
+@pytest.mark.parametrize("parallel_solver", [True, False])
+def test_matcher_speed(solver, parallel_solver: bool):
+    matcher = Matcher(default_solver=solver, adaptive_solver=False, parallel_solver=parallel_solver)
+    batch_size = 256
     rng = np.random.default_rng()
     times_all = []
     times_padded = []
 
-    for _ in range(1024):
+    for _ in range(16):
         n_objects = rng.integers(100, 250)
-        n_valid_objects = rng.integers(n_objects // 4, n_objects // 2)
-        cost = rng.random((1, n_objects, n_objects)) * 100  # Add batch dimension
-        object_valid_mask = np.zeros((1, n_objects), dtype=bool)  # Add batch dimension
-        object_valid_mask[0, :n_valid_objects] = True
-        cost[0, :, ~object_valid_mask[0]] = 1e8  # Set padding costs to infinity
+        cost, object_valid_mask = generate_dummy_cost(rng, batch_size, n_objects)
 
         # Convert to torch tensors
         cost_tensor = torch.from_numpy(cost).float()
@@ -73,4 +115,4 @@ def test_matcher_speed(solver):
 
     avg_time_all = np.mean(times_all)
     avg_time_padded = np.mean(times_padded)
-    print(f"Solver: {solver}, Avg Time All: {avg_time_all:.6f}s, Avg Time Padded: {avg_time_padded:.6f}s")
+    print(f"Solver: {solver} (parallel={parallel_solver}), Avg Time All: {avg_time_all:.6f}s, Avg Time Padded: {avg_time_padded:.6f}s")

--- a/tests/matching/test_match_equivalence.py
+++ b/tests/matching/test_match_equivalence.py
@@ -6,6 +6,7 @@ import torch
 
 from hepattn.models.matcher import SOLVERS, Matcher
 
+
 def generate_dummy_cost(rng: np.random.Generator, batch_size: int, n_objects: int, scale: float = 1.0) -> tuple[np.ndarray, np.ndarray]:
     cost = rng.random((batch_size, n_objects, n_objects)) * scale  # Add batch dimension
     object_valid_mask = np.zeros((batch_size, n_objects), dtype=bool)
@@ -50,6 +51,7 @@ def test_matcher_with_target_padding(solver, scale: float):
             f"Solver {solver} produced duplicate indices for padded n_objects={n_objects}, n_valid_objects={n_valid_objects}"
         )
 
+
 @pytest.mark.parametrize("solver", SOLVERS)
 @pytest.mark.parametrize("scale", [1.0, 10.0, 100.0, 1000.0])
 def test_matcher_with_parallel_solver(solver, scale: float):
@@ -72,20 +74,14 @@ def test_matcher_with_parallel_solver(solver, scale: float):
         assert idxs_parallel.shape == (batch_size, n_objects), (
             f"Parallel Solver {solver} produced incorrect shape for idxs: {idxs_parallel.shape}, expected {(batch_size, n_objects)}"
         )
-        assert np.all(
-            idxs_parallel[object_valid_mask] == idxs[object_valid_mask]
-        ), (
+        assert np.all(idxs_parallel[object_valid_mask] == idxs[object_valid_mask]), (
             f"Parallel Solver {solver} produced different indices for valid objects: {np.where(object_valid_mask)[0]}"
             f" for n_objects={n_objects}, batch_size={batch_size}, scale={scale}"
         )
-        assert np.all(
-            idxs_parallel[~object_valid_mask] == idxs[~object_valid_mask]
-        ), (
+        assert np.all(idxs_parallel[~object_valid_mask] == idxs[~object_valid_mask]), (
             f"Parallel Solver {solver} produced different indices for invalid objects: {np.where(~object_valid_mask)[0]}"
             f" for n_objects={n_objects}, batch_size={batch_size}, scale={scale}"
         )
-
-
 
 
 @pytest.mark.parametrize("solver", SOLVERS)


### PR DESCRIPTION
Add the possibility to do parallel matching. Mainly helps the scipy solver.

Solver: scipy (parallel=True), Avg Time All: 0.035956s, Avg Time Padded: 0.018119s
Solver: scipy (parallel=False), Avg Time All: 0.092293s, Avg Time Padded: 0.050787s

Solver: 1015_late (parallel=True), Avg Time All: 0.034346s, Avg Time Padded: 0.031926s
Solver: 1015_late (parallel=False), Avg Time All: 0.035553s, Avg Time Padded: 0.033345s

@samvanstroud 