### PR TITLE
Add decoder module

### DIFF
--- a/src/hepattn/experiments/cld/configs/base.yaml
+++ b/src/hepattn/experiments/cld/configs/base.yaml
@@ -354,10 +354,7 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_particles
       input_sort_field: pos.phi
-      use_attn_masks: true
-      use_query_masks: false
 
       input_nets:
         class_path: torch.nn.ModuleList
@@ -506,10 +503,13 @@ model:
           window_size: 1024
           window_wrap: true
 
-      num_decoder_layers: 8
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 8
+        num_queries: *num_particles
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/cld/configs/tracking.yaml
+++ b/src/hepattn/experiments/cld/configs/tracking.yaml
@@ -340,10 +340,7 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_particles
       input_sort_field: pos.phi
-      use_attn_masks: true
-      use_query_masks: false
 
       input_nets:
         class_path: torch.nn.ModuleList
@@ -427,10 +424,13 @@ model:
           window_size: 1024
           window_wrap: true
 
-      num_decoder_layers: 8
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 8
+        num_queries: *num_particles
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/clic/README.md
+++ b/src/hepattn/experiments/clic/README.md
@@ -2,7 +2,7 @@
 
 ```
 cd hepattn
-apptainer shell --nv --bind /share/ pixi.sif 
+apptainer shell --nv --bind /share/ pixi.sif
 pixi shell
 cd hepattn/src/hepattn/experiments/clic/
 python main.py fit --config configs/base.yaml

--- a/src/hepattn/experiments/clic/configs/base.yaml
+++ b/src/hepattn/experiments/clic/configs/base.yaml
@@ -90,9 +90,6 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_particles
-      use_attn_masks: true
-      use_query_masks: false
       raw_variables:
         - "node_e"
         - "node_pt"
@@ -126,13 +123,16 @@ model:
           attn_kwargs:
             num_heads: 16
 
-      num_decoder_layers: 4
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 4
+        num_queries: *num_particles
         mask_attention: true
-        hybrid_norm: true
-        attn_kwargs:
-          num_heads: 8
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
+          hybrid_norm: true
+          attn_kwargs:
+            num_heads: 8
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/itk/configs/tracking.yaml
+++ b/src/hepattn/experiments/itk/configs/tracking.yaml
@@ -95,7 +95,6 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: 1600
       input_sort_field: phi
 
       input_nets:
@@ -167,10 +166,13 @@ model:
           window_size: 512
           window_wrap: true
 
-      num_decoder_layers: 8
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 8
+        num_queries: 1600
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/pixel/configs/base.yaml
+++ b/src/hepattn/experiments/pixel/configs/base.yaml
@@ -158,10 +158,7 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 128
-      num_queries: *cluster_max_multiplicity
       input_sort_field: x
-      use_attn_masks: false
-      use_query_masks: false
 
       input_nets:
         class_path: torch.nn.ModuleList
@@ -201,10 +198,13 @@ model:
           dim: *dim
           attn_type: torch
 
-      num_decoder_layers: 2
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 2
+        num_queries: *cluster_max_multiplicity
         mask_attention: false
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/tide/configs/base.yaml
+++ b/src/hepattn/experiments/tide/configs/base.yaml
@@ -283,10 +283,7 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_tracks
       input_sort_field: phi
-      use_attn_masks: true
-      use_query_masks: false
       target_object: sudo
 
       input_nets:
@@ -408,10 +405,13 @@ model:
           dim: *dim
           attn_type: torch
 
-      num_decoder_layers: 4
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 4
+        num_queries: *num_tracks
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/tide/configs/pixel.yaml
+++ b/src/hepattn/experiments/tide/configs/pixel.yaml
@@ -283,10 +283,7 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_tracks
       input_sort_field: phi
-      use_attn_masks: true
-      use_query_masks: false
 
       input_nets:
         class_path: torch.nn.ModuleList
@@ -409,10 +406,13 @@ model:
           # window_size: 1024
           # window_wrap: false
 
-      num_decoder_layers: 8
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 8
+        num_queries: *num_tracks
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       matcher:
         class_path: hepattn.models.matcher.Matcher

--- a/src/hepattn/experiments/tide/configs/tagging/tide.yaml
+++ b/src/hepattn/experiments/tide/configs/tagging/tide.yaml
@@ -65,9 +65,6 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: 40
-      use_attn_masks: true
-      use_query_masks: false
 
       input_nets:
         class_path: torch.nn.ModuleList
@@ -188,10 +185,13 @@ model:
           dim: *dim
           attn_type: torch
 
-      num_decoder_layers: 4
-      decoder_layer_config:
-        dim: *dim
+      decoder:
+        num_decoder_layers: 4
+        num_queries: 40
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
 
       pooling:
         class_path: hepattn.models.pooling.Pooling

--- a/src/hepattn/experiments/trackml/configs/tracking-lite.yaml
+++ b/src/hepattn/experiments/trackml/configs/tracking-lite.yaml
@@ -123,7 +123,6 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_objects
       input_sort_field: phi
       input_nets:
         class_path: torch.nn.ModuleList
@@ -177,11 +176,14 @@ model:
           hybrid_norm: true
           norm: RMSNorm
 
-      num_decoder_layers: 4
-      decoder_layer_config:
-        dim: *dim
-        norm: RMSNorm
+      decoder:
+        num_decoder_layers: 4
+        num_queries: *num_objects
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
+          norm: RMSNorm
 
       tasks:
         class_path: torch.nn.ModuleList

--- a/src/hepattn/experiments/trackml/configs/tracking.yaml
+++ b/src/hepattn/experiments/trackml/configs/tracking.yaml
@@ -121,7 +121,6 @@ model:
     class_path: hepattn.models.MaskFormer
     init_args:
       dim: &dim 256
-      num_queries: *num_objects
       input_sort_field: phi
       input_nets:
         class_path: torch.nn.ModuleList
@@ -175,11 +174,14 @@ model:
           hybrid_norm: true
           norm: RMSNorm
 
-      num_decoder_layers: 4
-      decoder_layer_config:
-        dim: *dim
-        norm: RMSNorm
+      decoder:
+        num_decoder_layers: 4
+        num_queries: *num_objects
         mask_attention: true
+        use_query_masks: false
+        decoder_layer_config:
+          dim: *dim
+          norm: RMSNorm
 
       tasks:
         class_path: torch.nn.ModuleList

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -88,6 +88,9 @@ class MaskFormerDecoder(nn.Module):
             query_mask = None
 
             for task in self.tasks:
+                if not task.has_intermediate_loss:
+                    continue
+
                 # Get the outputs of the task given the current embeddings
                 task_outputs = task(x)
 

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -88,9 +88,6 @@ class MaskFormerDecoder(nn.Module):
             query_mask = None
 
             for task in self.tasks:
-                if not task.has_intermediate_loss:
-                    continue
-
                 # Get the outputs of the task given the current embeddings
                 task_outputs = task(x)
 

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -145,9 +145,9 @@ class MaskFormerDecoder(nn.Module):
             # Re-add original embeddings (similar to SAM's prompt token re-addition)
             x = self.re_add_original_embeddings(x)
 
-            # Unmerge the updated features back into separate input types
-            for input_name in input_names:
-                x[input_name + "_embed"] = x["key_embed"][..., x[f"key_is_{input_name}"], :]
+        # Unmerge the updated features back into separate input types
+        for input_name in input_names:
+            x[input_name + "_embed"] = x["key_embed"][..., x[f"key_is_{input_name}"], :]
 
         return x, outputs
 

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -10,7 +10,160 @@ from torch import Tensor, nn
 
 from hepattn.models.attention import Attention
 from hepattn.models.dense import Dense
+from hepattn.models.task import IncidenceRegressionTask, ObjectClassificationTask
 from hepattn.models.transformer import Residual
+
+
+class MaskFormerDecoder(nn.Module):
+    def __init__(
+        self,
+        num_queries: int,
+        decoder_layer_config: dict,
+        num_decoder_layers: int,
+        mask_attention: bool = True,
+        use_query_masks: bool = False,
+        log_attn_mask: bool = False,
+        query_posenc: nn.Module | None = None,
+        preserve_posenc: bool = False,
+    ):
+        """MaskFormer decoder that handles multiple decoder layers and task integration.
+
+        Parameters
+        ----------
+        num_queries : int
+            The number of object-level queries.
+        decoder_layer_config : dict
+            Configuration dictionary used to initialize each MaskFormerDecoderLayer.
+        num_decoder_layers : int
+            The number of decoder layers to stack.
+        mask_attention : bool, optional
+            If True, attention masks will be used to control which input objects are attended to.
+        use_query_masks : bool, optional
+            If True, predicted query masks will be used to control which queries are valid.
+            May be useful when providing initial queries as inputs.
+        log_attn_mask : bool, optional
+            If True, log attention masks for debugging.
+        """
+        super().__init__()
+
+        # Ensure mask_attention is passed to decoder layers
+        decoder_layer_config = decoder_layer_config.copy()
+        decoder_layer_config["mask_attention"] = mask_attention
+
+        self.decoder_layers = nn.ModuleList([MaskFormerDecoderLayer(depth=i, **decoder_layer_config) for i in range(num_decoder_layers)])
+        self.tasks = None  # Will be set by MaskFormer
+        self.num_queries = num_queries
+        self.mask_attention = mask_attention
+        self.use_query_masks = use_query_masks
+        self.log_attn_mask = log_attn_mask
+        self.query_posenc = query_posenc
+        self.preserve_posenc = preserve_posenc
+        self.log_step = 0
+
+    def forward(self, x: dict[str, Tensor], input_names: list[str]) -> dict[str, dict]:
+        """Forward pass through decoder layers.
+
+        Parameters
+        ----------
+        x : dict[str, Tensor]
+            Dictionary containing embeddings and masks.
+        input_names : list[str]
+            List of input names for constructing attention masks.
+
+        Returns:
+        -------
+        dict[str, dict]
+            Outputs from each decoder layer and final outputs.
+        """
+        batch_size = x["query_embed"].shape[0]
+        num_constituents = x["key_embed"].shape[-2]
+        self.log_step += 1
+
+        outputs = {}
+
+        for layer_index, decoder_layer in enumerate(self.decoder_layers):
+            outputs[f"layer_{layer_index}"] = {}
+
+            attn_masks = {}
+            query_mask = None
+
+            for task in self.tasks:
+                # Get the outputs of the task given the current embeddings
+                task_outputs = task(x)
+
+                # Update x with task outputs for downstream use
+                if isinstance(task, IncidenceRegressionTask):
+                    x["incidence"] = task_outputs[task.outputs[0]].detach()
+                if isinstance(task, ObjectClassificationTask):
+                    x["class_probs"] = task_outputs[task.outputs[0]].detach()
+
+                outputs[f"layer_{layer_index}"][task.name] = task_outputs
+
+                # Collect attention masks from tasks
+                task_attn_masks = task.attn_mask(task_outputs)
+                for input_name, attn_mask in task_attn_masks.items():
+                    if input_name in attn_masks:
+                        attn_masks[input_name] |= attn_mask
+                    else:
+                        attn_masks[input_name] = attn_mask
+
+                # Collect query masks
+                if self.use_query_masks:
+                    task_query_mask = task.query_mask(task_outputs)
+                    if task_query_mask is not None:
+                        query_mask = task_query_mask if query_mask is None else query_mask | task_query_mask
+
+            # Construct the full attention mask for MaskAttention decoder
+            attn_mask = None
+            if attn_masks and self.mask_attention:
+                attn_mask = torch.full((batch_size, self.num_queries, num_constituents), True, device=x["key_embed"].device)
+                for input_name, task_attn_mask in attn_masks.items():
+                    attn_mask[..., x[f"key_is_{input_name}"]] = task_attn_mask
+
+            # Log attention mask if requested
+            if self.log_attn_mask and (attn_mask is not None) and (self.log_step % 1000 == 0):
+                if not hasattr(self, "attn_masks_to_log"):
+                    self.attn_masks_to_log = {}
+                if layer_index == 0 or layer_index == len(self.decoder_layers) - 1:
+                    self.attn_masks_to_log[layer_index] = {
+                        "mask": attn_mask[0].detach().cpu().clone(),
+                        "step": self.log_step,
+                        "layer": layer_index,
+                    }
+
+            # Add query positional encodings
+            x = self.add_query_posenc(x)
+
+            # Update embeddings through decoder layer
+            x["query_embed"], x["key_embed"] = decoder_layer(
+                x["query_embed"], x["key_embed"], attn_mask=attn_mask, q_mask=query_mask, kv_mask=x.get("key_valid")
+            )
+
+            # Re-add original embeddings (similar to SAM's prompt token re-addition)
+            x = self.re_add_original_embeddings(x)
+
+            # Unmerge the updated features back into separate input types
+            for input_name in input_names:
+                x[input_name + "_embed"] = x["key_embed"][..., x[f"key_is_{input_name}"], :]
+
+        return x, outputs
+
+    def re_add_original_embeddings(self, x: dict):
+        # Re-add original query embeddings (similar to SAM's prompt token re-addition)
+        if self.preserve_posenc:
+            x["key_embed"] = x["key_embed"] + x["key_posenc"]
+            if self.query_posenc is not None:
+                x["query_embed"] = x["query_embed"] + x["query_posenc"]
+        return x
+
+    def add_query_posenc(self, x: dict):
+        if self.query_posenc is not None:
+            # The query positional encoding is static, so we compute it once and cache it in `x`.
+            if "query_posenc" not in x:
+                x["query_phi"] = 2 * torch.pi * (torch.arange(self.num_queries, device=x["query_embed"].device) / self.num_queries - 0.5)
+                x["query_posenc"] = self.query_posenc(x)
+            x["query_embed"] = x["query_embed"] + x["query_posenc"]
+        return x
 
 
 class MaskFormerDecoderLayer(nn.Module):

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -60,7 +60,7 @@ class MaskFormerDecoder(nn.Module):
         self.preserve_posenc = preserve_posenc
         self.log_step = 0
 
-    def forward(self, x: dict[str, Tensor], input_names: list[str]) -> dict[str, dict]:
+def forward(self, x: dict[str, Tensor], input_names: list[str]) -> tuple[dict[str, Tensor], dict[str, dict]]:
         """Forward pass through decoder layers.
 
         Parameters

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -60,7 +60,7 @@ class MaskFormerDecoder(nn.Module):
         self.preserve_posenc = preserve_posenc
         self.log_step = 0
 
-def forward(self, x: dict[str, Tensor], input_names: list[str]) -> tuple[dict[str, Tensor], dict[str, dict]]:
+    def forward(self, x: dict[str, Tensor], input_names: list[str]) -> tuple[dict[str, Tensor], dict[str, dict]]:
         """Forward pass through decoder layers.
 
         Parameters

--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -145,9 +145,9 @@ class MaskFormerDecoder(nn.Module):
             # Re-add original embeddings (similar to SAM's prompt token re-addition)
             x = self.re_add_original_embeddings(x)
 
-        # Unmerge the updated features back into separate input types
-        for input_name in input_names:
-            x[input_name + "_embed"] = x["key_embed"][..., x[f"key_is_{input_name}"], :]
+            # Unmerge the updated features back into separate input types for intermediate tasks
+            for input_name in input_names:
+                x[input_name + "_embed"] = x["key_embed"][..., x[f"key_is_{input_name}"], :]
 
         return x, outputs
 

--- a/src/hepattn/models/maskformer.py
+++ b/src/hepattn/models/maskformer.py
@@ -154,23 +154,6 @@ class MaskFormer(nn.Module):
 
         return outputs
 
-    def re_add_original_embeddings(self, x: dict):
-        # Re-add original query embeddings (similar to SAM's prompt token re-addition)
-        if self.preserve_posenc:
-            x["key_embed"] = x["key_embed"] + x["key_posenc"]
-            if self.query_posenc is not None:
-                x["query_embed"] = x["query_embed"] + x["query_posenc"]
-        return x
-
-    def add_query_posenc(self, x: dict):
-        if self.query_posenc is not None:
-            # The query positional encoding is static, so we compute it once and cache it in `x`.
-            if "query_posenc" not in x:
-                x["query_phi"] = 2 * torch.pi * (torch.arange(self.num_queries, device=x["query_embed"].device) / self.num_queries - 0.5)
-                x["query_posenc"] = self.query_posenc(x)
-            x["query_embed"] = x["query_embed"] + x["query_posenc"]
-        return x
-
     def predict(self, outputs: dict) -> dict:
         """Takes the raw model outputs and produces a set of actual inferences / predictions.
         For example will take output probabilies and apply threshold cuts to prduce boolean predictions.

--- a/src/hepattn/models/maskformer.py
+++ b/src/hepattn/models/maskformer.py
@@ -142,11 +142,6 @@ class MaskFormer(nn.Module):
         # Do any pooling if desired
         if self.pooling is not None:
             x_pooled = self.pooling(x[f"{self.pooling.input_name}_embed"], x[f"{self.pooling.input_name}_valid"])
-            x[f"{self.pooling.output_name}_embed"] = x | x_pooled
-
-        # Do any pooling if desired
-        if self.pooling is not None:
-            x_pooled = self.pooling(x[f"{self.pooling.input_name}_embed"], x[f"{self.pooling.input_name}_valid"])
             x[f"{self.pooling.output_name}_embed"] = x_pooled
 
         # Get the final outputs - we don't need to compute attention masks or update things here

--- a/src/hepattn/models/maskformer.py
+++ b/src/hepattn/models/maskformer.py
@@ -77,14 +77,8 @@ class MaskFormer(nn.Module):
 
         # Store input positional encodings if we need to preserve them for the decoder
         if self.decoder.preserve_posenc:
-            input_posencs = []
-            for input_net in self.input_nets:
-                if input_net.posenc is not None:
-                    posenc = input_net.posenc(inputs)
-                    input_posencs.append(posenc)
-                else:
-                    raise ValueError(f"Input net {input_net.input_name} has no positional encoding.")
-            x["key_posenc"] = torch.concatenate(input_posencs, dim=-2)
+            assert all(input_net.posenc is not None for input_net in self.input_nets)
+            x["key_posenc"] = torch.concatenate([input_net.posenc(inputs) for input_net in self.input_nets], dim=-2)
 
         # Embed the input objects
         for input_net in self.input_nets:

--- a/src/hepattn/models/task.py
+++ b/src/hepattn/models/task.py
@@ -1211,11 +1211,10 @@ class IncidenceBasedRegressionTask(RegressionTask):
             target = targets[self.target_object + "_" + field][targets[self.target_object + "_valid"]]
             # Get the error between the prediction and target for this field
             err = pred - target
-            # Compute the RMSE and log it
             metrics[field + "_rmse"] = torch.sqrt(torch.mean(torch.square(err)))
-            # Compute the relative error / resolution and log it
-            metrics[field + "_mean_res"] = torch.mean(err / target)
-            metrics[field + "_std_res"] = torch.std(err / target)
+            metrics[field + "_abs_res"] = err.abs().mean()
+            metrics[field + "_mean_norm_res"] = torch.mean(err / target)
+            metrics[field + "_std_norm_res"] = torch.std(err / target)
 
         return metrics
 

--- a/tests/models/test_decoder.py
+++ b/tests/models/test_decoder.py
@@ -73,7 +73,7 @@ class TestMaskFormerDecoder:
         assert decoder.preserve_posenc is False
 
         # Check that decoder layers are initialized correctly
-        for i, layer in enumerate(decoder.decoder_layers):
+        for layer in decoder.decoder_layers:
             assert isinstance(layer, MaskFormerDecoderLayer)
             assert layer.mask_attention is True
 

--- a/tests/models/test_decoder.py
+++ b/tests/models/test_decoder.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from hepattn.models.decoder import MaskFormerDecoderLayer
+from hepattn.models.decoder import MaskFormerDecoder, MaskFormerDecoderLayer
 
 BATCH_SIZE = 2
 SEQ_LEN = 10
@@ -12,7 +12,141 @@ NUM_HEADS = 8
 HEAD_DIM = DIM // NUM_HEADS
 
 
-# Now let's write the tests
+class TestMaskFormerDecoder:
+    @pytest.fixture
+    def decoder_layer_config(self):
+        return {
+            "dim": DIM,
+            "norm": "LayerNorm",
+            "dense_kwargs": {},
+            "attn_kwargs": {},
+            "bidirectional_ca": True,
+            "hybrid_norm": False,
+        }
+
+    @pytest.fixture
+    def decoder(self, decoder_layer_config):
+        return MaskFormerDecoder(
+            num_queries=NUM_QUERIES,
+            decoder_layer_config=decoder_layer_config,
+            num_decoder_layers=NUM_LAYERS,
+            mask_attention=True,
+        )
+
+    @pytest.fixture
+    def decoder_no_mask_attention(self, decoder_layer_config):
+        """Decoder with mask_attention=False for testing without tasks."""
+        config = decoder_layer_config.copy()
+        return MaskFormerDecoder(
+            num_queries=NUM_QUERIES,
+            decoder_layer_config=config,
+            num_decoder_layers=NUM_LAYERS,
+            mask_attention=False,
+        )
+
+    @pytest.fixture
+    def sample_decoder_data(self):
+        x = {
+            "query_embed": torch.randn(BATCH_SIZE, NUM_QUERIES, DIM),
+            "key_embed": torch.randn(BATCH_SIZE, SEQ_LEN, DIM),
+            "key_posenc": torch.randn(BATCH_SIZE, SEQ_LEN, DIM),
+            "key_valid": torch.ones(BATCH_SIZE, SEQ_LEN, dtype=torch.bool),
+            "key_is_input1": torch.zeros(SEQ_LEN, dtype=torch.bool),
+            "key_is_input2": torch.zeros(SEQ_LEN, dtype=torch.bool),
+        }
+        # Set some positions to be input1 and input2
+        x["key_is_input1"][:3] = True
+        x["key_is_input2"][3:6] = True
+
+        input_names = ["input1", "input2"]
+        return x, input_names
+
+    def test_initialization(self, decoder, decoder_layer_config):
+        """Test that the decoder initializes correctly."""
+        assert decoder.num_queries == NUM_QUERIES
+        assert decoder.mask_attention is True
+        assert decoder.use_query_masks is False
+        assert decoder.log_attn_mask is False
+        assert len(decoder.decoder_layers) == NUM_LAYERS
+        assert decoder.tasks is None
+        assert decoder.query_posenc is None
+        assert decoder.preserve_posenc is False
+
+        # Check that decoder layers are initialized correctly
+        for i, layer in enumerate(decoder.decoder_layers):
+            assert isinstance(layer, MaskFormerDecoderLayer)
+            assert layer.mask_attention is True
+
+    def test_initialization_with_options(self, decoder_layer_config):
+        """Test initialization with various options."""
+        decoder = MaskFormerDecoder(
+            num_queries=NUM_QUERIES,
+            decoder_layer_config=decoder_layer_config,
+            num_decoder_layers=NUM_LAYERS,
+            mask_attention=False,
+            use_query_masks=True,
+            log_attn_mask=True,
+        )
+
+        assert decoder.mask_attention is False
+        assert decoder.use_query_masks is True
+        assert decoder.log_attn_mask is True
+
+    def test_forward_without_tasks(self, decoder_no_mask_attention, sample_decoder_data):
+        """Test forward pass without any tasks defined."""
+        x, input_names = sample_decoder_data
+        decoder_no_mask_attention.tasks = []  # Empty task list
+
+        updated_x, outputs = decoder_no_mask_attention(x, input_names)
+
+        # Check that x was updated with new embeddings
+        assert "query_embed" in updated_x
+        assert "key_embed" in updated_x
+        assert updated_x["query_embed"].shape == (BATCH_SIZE, NUM_QUERIES, DIM)
+        assert updated_x["key_embed"].shape == (BATCH_SIZE, SEQ_LEN, DIM)
+
+        # Check outputs structure
+        assert len(outputs) == NUM_LAYERS
+        for i in range(NUM_LAYERS):
+            assert f"layer_{i}" in outputs
+            assert isinstance(outputs[f"layer_{i}"], dict)
+
+    def test_forward_shapes(self, decoder_no_mask_attention, sample_decoder_data):
+        """Test that forward pass maintains correct tensor shapes."""
+        x, input_names = sample_decoder_data
+        decoder_no_mask_attention.tasks = []
+
+        original_query_shape = x["query_embed"].shape
+        original_key_shape = x["key_embed"].shape
+
+        updated_x, _ = decoder_no_mask_attention(x, input_names)
+
+        assert updated_x["query_embed"].shape == original_query_shape
+        assert updated_x["key_embed"].shape == original_key_shape
+
+    def test_add_query_posenc_no_posenc(self, decoder, sample_decoder_data):
+        """Test add_query_posenc when no positional encoding is set."""
+        x, _ = sample_decoder_data
+        original_embed = x["query_embed"].clone()
+
+        updated_x = decoder.add_query_posenc(x)
+
+        # Should remain unchanged when no query_posenc is set
+        assert torch.equal(updated_x["query_embed"], original_embed)
+
+    def test_re_add_original_embeddings_no_preserve(self, decoder, sample_decoder_data):
+        """Test re_add_original_embeddings when preserve_posenc is False."""
+        x, _ = sample_decoder_data
+        original_query = x["query_embed"].clone()
+        original_key = x["key_embed"].clone()
+
+        updated_x = decoder.re_add_original_embeddings(x)
+
+        # Should remain unchanged when preserve_posenc is False
+        assert torch.equal(updated_x["query_embed"], original_query)
+        assert torch.equal(updated_x["key_embed"], original_key)
+
+
 class TestMaskFormerDecoderLayer:
     @pytest.fixture
     def decoder_layer(self):


### PR DESCRIPTION
- extract decoder logic to dedicated module
- `use_query_masks` defaults to `False`
- fix pooling logic (happens outside decoder now)
- avoid `ask_query_mask = task.query_mask(task_outputs)` if `self.use_query_masks == False` 
- harmonise `use_attn_masks` and `mask_attention` arguments