### PR TITLE
Tweak mask attention unmasking

### DIFF
--- a/src/hepattn/models/decoder.py
+++ b/src/hepattn/models/decoder.py
@@ -139,6 +139,7 @@ class MaskFormerDecoder(nn.Module):
                 attn_mask = attn_mask.detach()
                 # True values indicate a slot will be included in the attention computation, while False will be ignored.
                 # If the attn mask is completely invalid for a given query, allow it to attend everywhere
+                # TODO: check and see see if this is really necessary
                 attn_mask = torch.where(torch.all(~attn_mask, dim=-1, keepdim=True), True, attn_mask)
 
             if attn_mask is not None:

--- a/src/hepattn/models/task.py
+++ b/src/hepattn/models/task.py
@@ -291,11 +291,6 @@ class ObjectHitMaskTask(Task):
             return {}
 
         attn_mask = outputs[self.output_object_hit + "_logit"].detach().sigmoid() >= threshold
-
-        # if a input constituent does not attend to any queries, let it attend to all
-        # TODO: looks flipped, check it and see see if this is really necessary
-        attn_mask[torch.where(torch.all(attn_mask, dim=-1))] = False
-
         return {self.input_constituent: attn_mask}
 
     def predict(self, outputs: dict[str, Tensor]) -> dict[str, Tensor]:


### PR DESCRIPTION
might be useful for @trahxam - the unmasking already happens in the decoder, so no need to do it for each task separately. this might prevent e.g. neutrals from being forced to attend to tracker hits.