### PR TITLE
enable elementwise affine in norm layers explicitly

### DIFF
--- a/src/hepattn/models/encoder.py
+++ b/src/hepattn/models/encoder.py
@@ -87,8 +87,8 @@ class Residual(nn.Module):
         self.dp = DropPath(drop_path) if drop_path else nn.Identity()
         self.post_norm = post_norm
 
-        self.norm = getattr(nn, norm)(dim) if norm else nn.Identity()
-        self.kv_norm = getattr(nn, norm)(dim) if kv_norm and norm else None
+        self.norm = getattr(nn, norm)(dim, elementwise_affine=True) if norm else nn.Identity()
+        self.kv_norm = getattr(nn, norm)(dim, elementwise_affine=True) if kv_norm and norm else None
 
     def forward(self, x: Tensor, **kwargs) -> Tensor:
         if self.post_norm:


### PR DESCRIPTION
Looks like it helps for qkvnorma and hybridnorm

<img width="517" height="250" alt="Screenshot 2025-11-17 at 19 05 01" src="https://github.com/user-attachments/assets/4643843b-83f3-49f9-a549-84fabcf609d4" />
<img width="739" height="696" alt="Screenshot 2025-11-17 at 19 04 59" src="https://github.com/user-attachments/assets/2e39e235-40f8-4ff6-8266-008f290218a8" />
